### PR TITLE
move validation to after setting env variables

### DIFF
--- a/miqScore16SPublicSupport/parameters/environmentParameterParser.py
+++ b/miqScore16SPublicSupport/parameters/environmentParameterParser.py
@@ -49,9 +49,9 @@ class EnvVariable(object):
         self.logLevel = logLevel
         self.externalValidation = externalValidation
         self.setValueValidations()
-        self.runValidations()
         self.environmentVariableName = name.upper()
         self.usingDefaultValue = not self.setEnvironmentValue()
+        self.runValidations()
 
     def setValueValidations(self):
         if self.lowerBound is None and self.upperBound is None:


### PR DESCRIPTION
**Problem:** program still checks the default /data/input/sequence/standard_submitted_R1.fastq and /data/input/sequence/standard_submitted_R2.fastq location even if FORWARDREADS and REVERSEREADS are set. This results in a file not found error. 
Code run:
```
  export FORWARDREADS=$PWD/test_downsample_R1.fastq.gz
  export REVERSEREADS=$PWD/test_downsample_R2.fastq.gz
  mkdir output
  export OUTPUTFOLDER=$PWD/output
  export LOGFILE=$PWD/miqcore16s.log
  export SAMPLENAME=test
  export FORWARDPRIMERLENGTH=17
  export REVERSEPRIMERLENGTH=24
  export AMPLICONLENGTH=510
  python3 /opt/miqscore16s/analyzeStandardReads.py
```
Error message:
```
Command error:
  Unable to find expected file for environment variable parameter forwardReads at /data/input/sequence/standard_submitted_R1.fastq
  Traceback (most recent call last):
    File "/opt/miqscore16s/analyzeStandardReads.py", line 408, in <module>
      parameters = getApplicationParameters()
    File "/opt/miqscore16s/analyzeStandardReads.py", line 13, in getApplicationParameters
      parameters.addParameter("forwardReads", str, default = default.forwardReads, expectedFile=True)
    File "/opt/miqscore16s/miqScore16SPublicSupport/parameters/environmentParameterParser.py", line 393, in addParameter
      parameter = EnvVariable(name, typeRequirement, default, flag, validationList, lowerBound, upperBound, expectedFile, createdFile, expectedDirectory, createdDirectory, logLevel, required, externalValidation)
    File "/opt/miqscore16s/miqScore16SPublicSupport/parameters/environmentParameterParser.py", line 52, in __init__
      self.runValidations()
    File "/opt/miqscore16s/miqScore16SPublicSupport/parameters/environmentParameterParser.py", line 85, in runValidations
      self.validateExpectedFilePath()
    File "/opt/miqscore16s/miqScore16SPublicSupport/parameters/environmentParameterParser.py", line 121, in validateExpectedFilePath
      raise FileNotFoundError("Unable to find expected file %s" %self.value)
  FileNotFoundError: Unable to find expected file /data/input/sequence/standard_submitted_R1.fastq
```
**Cause:** EnvVariable class in the helper code runs validation *before* getting the values of environmental variables.
**Solution:** Move the validation to after getting the values of environmental variables. This has been tested. 